### PR TITLE
update OCP-29797 post upgrade check for grafana change

### DIFF
--- a/features/upgrade/monitoring/monitoring-upgrade.feature
+++ b/features/upgrade/monitoring/monitoring-upgrade.feature
@@ -62,18 +62,6 @@ Feature: cluster monitoring related upgrade check
     And the output should contain:
       | Watchdog |
 
-    # curl -k -H "Authorization: Bearer $token" https://grafana.openshift-monitoring.svc:3000/api/health
-    When I run the :exec admin command with:
-      | n                | openshift-monitoring |
-      | pod              | prometheus-k8s-0     |
-      | c                | prometheus           |
-      | oc_opts_end      |                      |
-      | exec_command     | sh                   |
-      | exec_command_arg | -c                   |
-      | exec_command_arg | curl -k -H "Authorization: Bearer <%= cb.sa_token %>" https://grafana.openshift-monitoring.svc:3000/api/health |
-    Then the step should succeed
-    And the output should contain:
-      | ok |
     When I run the :oadm_top_node admin command
     Then the output should contain:
       | CPU(cores) |


### PR DESCRIPTION
Since 4.11 removed Grafana resources, these codes should be removed as well.